### PR TITLE
Task 1: Style a Product Card

### DIFF
--- a/assets/component-card.css
+++ b/assets/component-card.css
@@ -142,6 +142,9 @@
   align-self: flex-end;
   grid-row-start: 3;
   justify-self: flex-start;
+  display: flex;
+  gap: calc(var(--image-padding) + 1rem);
+  flex-wrap: wrap;
 }
 
 .card__badge.top {
@@ -362,3 +365,58 @@
 .card-article-info {
   margin-top: 1rem;
 }
+
+.card-swatches {
+  display: flex;
+  gap: 20px;
+  margin-top: 1rem !important;
+  flex-wrap: wrap;
+}
+
+.card-swatches__item {
+  /* The outer size */
+  width: 30px; 
+  height: 30px;
+  border: 1px solid rgba(var(--color-foreground), 0.25);
+  border-radius: 50%;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: border-color 0.3s ease;
+}
+
+.card-swatches__item--active {
+  border: 2px solid rgba(var(--color-foreground));
+}
+
+.card-swatches__inner {
+  /* The swatch is smaller than it's container */
+  width: 75%; 
+  height: 75%;
+
+  /* Ensures clean circular design */
+  border-radius: 50%;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.card-swatches__swatch {
+  width: 100%;
+  height: 100%;
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+
+  /* Ensures inner swatch is circular */
+  border-radius: 50%;
+}
+
+.card-information__row {
+  display: flex;
+  justify-content: space-between;
+}
+
+

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -2,7 +2,7 @@
   {
     "name": "theme_info",
     "theme_name": "Generated Data Theme",
-    "theme_version": "1.0.0",
+    "theme_version": "1.0.1",
     "theme_author": "Shopify",
     "theme_documentation_url": "https:\/\/shopify.dev\/docs\/apps\/tools\/development-stores\/generated-data#themes\/",
     "theme_support_url": "https:\/\/shopify.dev\/docs\/apps\/tools\/development-stores\/generated-data#themes\/"

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -1334,6 +1334,35 @@
         ],
         "default": "inverse",
         "label": "t:settings_schema.badges.settings.sold_out_badge_color_scheme.label"
+      },
+      {
+        "type": "select",
+        "id": "custom_badge_color_scheme",
+        "options": [
+          {
+            "value": "accent-1",
+            "label": "t:sections.all.colors.accent_1.label"
+          },
+          {
+            "value": "accent-2",
+            "label": "t:sections.all.colors.accent_2.label"
+          },
+          {
+            "value": "background-1",
+            "label": "t:sections.all.colors.background_1.label"
+          },
+          {
+            "value": "background-2",
+            "label": "t:sections.all.colors.background_2.label"
+          },
+          {
+            "value": "inverse",
+            "label": "t:sections.all.colors.inverse.label"
+          }
+        ],
+        "default": "inverse",
+        "label": "t:settings_schema.badges.settings.custom_badge_color_scheme.label",
+        "info": "t:settings_schema.badges.settings.custom_badge_color_scheme.info"
       }
     ]
   },

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -108,6 +108,10 @@
         },
         "sold_out_badge_color_scheme": {
           "label": "Sold out badge color scheme"
+        },
+        "custom_badge_color_scheme": {
+          "label": "Custom badge color scheme",
+          "info": "Add custom badges using product tags beginning with 'badge_'."
         }
       }
     },

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -121,6 +121,7 @@
               <span
                 id="NoMediaStandardBadge-{{ section_id }}-{{ card_product.id }}"
                 class="badge badge--bottom-left color-{{ settings.sold_out_badge_color_scheme }}"
+                aria-label="{{ 'products.product.sold_out' | t }}"
               >
                 {{- 'products.product.sold_out' | t -}}
               </span>
@@ -128,10 +129,29 @@
               <span
                 id="NoMediaStandardBadge-{{ section_id }}-{{ card_product.id }}"
                 class="badge badge--bottom-left color-{{ settings.sale_badge_color_scheme }}"
+                aria-label="{{ 'products.product.on_sale' | t }}"
               >
                 {{- 'products.product.on_sale' | t -}}
               </span>
             {%- endif -%}
+            
+            {% comment %}
+              Renders custom badges. 
+              These are defined as product tags prefixed with 'badge_'.
+            {% endcomment %}
+            {%- for tag in card_product.tags -%}
+              {%- assign prefix = tag | slice: 0, 6 -%}
+              {%- if prefix == 'badge_' -%}
+                {%- assign badge_title = tag | remove: 'badge_' | replace: '_', ' ' -%}
+                <span
+                  id="CustomBadge-{{ section_id }}-{{ card_product.id }}-{{ badge_title | handle }}"
+                  class="badge badge--bottom-left color-{{ settings.custom_badge_color_scheme }}"
+                  aria-label="{{ badge_title }}"
+                >
+                  {{ badge_title }}
+                </span>
+              {%- endif -%}
+            {%- endfor -%}
           </div>
         </div>
       </div>
@@ -159,44 +179,72 @@
             {%- endif -%}
 
             <span class="caption-large light">{{ block.settings.description | escape }}</span>
+            
+            {% comment %}
+              Renders swatches for products that are part of this products group.
+              The product group is defined in the product's metafields.
+            {% endcomment %}
+            {%- if card_product.metafields.custom.product_group.value != blank -%}
+              {%- assign product_list = card_product.metafields.custom.product_group.value.products.value -%}
 
-            {%- if show_rating and card_product.metafields.reviews.rating.value != blank -%}
-              {% liquid
-                assign rating_decimal = 0
-                assign decimal = card_product.metafields.reviews.rating.value.rating | modulo: 1
-                if decimal >= 0.3 and decimal <= 0.7
-                  assign rating_decimal = 0.5
-                elsif decimal > 0.7
-                  assign rating_decimal = 1
-                endif
-              %}
-              <div
-                class="rating"
-                role="img"
-                aria-label="{{ 'accessibility.star_reviews_info' | t: rating_value: card_product.metafields.reviews.rating.value, rating_max: card_product.metafields.reviews.rating.value.scale_max }}"
-              >
-                <span
-                  aria-hidden="true"
-                  class="rating-star color-icon-{{ settings.accent_icons }}"
-                  style="--rating: {{ card_product.metafields.reviews.rating.value.rating | floor }}; --rating-max: {{ card_product.metafields.reviews.rating.value.scale_max }}; --rating-decimal: {{ rating_decimal }};"
-                ></span>
-              </div>
-              <p class="rating-text caption">
-                <span aria-hidden="true">
-                  {{- card_product.metafields.reviews.rating.value }} /
-                  {{ card_product.metafields.reviews.rating.value.scale_max -}}
-                </span>
-              </p>
-              <p class="rating-count caption">
-                <span aria-hidden="true">({{ card_product.metafields.reviews.rating_count }})</span>
-                <span class="visually-hidden">
-                  {{- card_product.metafields.reviews.rating_count }}
-                  {{ 'accessibility.total_reviews' | t -}}
-                </span>
-              </p>
+              {%- if product_list.count > 0 -%}
+                <div class="card-swatches">
+                  {%- for product in product_list -%}
+                    {%- if product.metafields.custom.product_colour.value != blank -%}
+                      <a  
+                        id="Swatch-{{ section_id }}-{{ card_product.id }}-{{ product.id }}"
+                        data-product-id="{{ product.id }}"
+                        class="card-swatches__item{%- if product == card_product %} card-swatches__item--active{%- endif -%}"
+                        href="{{ product.url }}" 
+                        aria-label="{{ product.metafields.custom.product_colour.value.label.value }}"
+                      >
+                        <div class="card-swatches__inner">
+                          <div
+                            class="card-swatches__swatch"
+                            style="
+                              {%- if product.metafields.custom.product_colour.value.image.value != blank -%}
+                                background-image: url({{ product.metafields.custom.product_colour.value.image | img_url: '1x1' }});
+                              {%- elsif product.metafields.custom.product_colour.value.colour.value != blank -%}
+                                background-color: {{ product.metafields.custom.product_colour.value.colour }};
+                              {%- endif -%}"
+                          >
+                          </div>
+                        </div>
+                      </a>
+                    {%- endif -%}
+                  {%- endfor -%}
+                </div>
+              {%- endif -%}
             {%- endif -%}
 
-            {% render 'price', product: card_product, price_class: '' %}
+            <div class= "card-information__row">
+              {% render 'price', product: card_product, price_class: '' %}
+
+              {%- comment -%}
+                Use custom product rating metafield rather than the default Shopify review rating fields.
+              {%- endcomment -%}
+              {%- if show_rating and card_product.metafields.custom.product_rating.value != blank -%}
+                
+                {% liquid
+                  assign rating_value = card_product.metafields.custom.product_rating.value
+                  assign rating_max = 5
+                %}
+                <div
+                  class="rating"
+                  role="img"
+                  aria-label="{{ 'accessibility.star_reviews_info' | t: rating_value: rating_value, rating_max: rating_max }}"
+                >
+                  <span
+                    aria-hidden="true"
+                    class="color-icon-{{ settings.accent_icons }}"
+                  >&#x2605;</span>
+                  <span
+                    aria-hidden="true">
+                    {{- rating_value -}}
+                  </span>
+                </div>
+              {%- endif -%}
+            </div>  
           </div>
         </div>
         {%- if show_quick_add -%}


### PR DESCRIPTION
Completed task 1 from the [Developer Brief](https://github.com/abelandjones/eleven-interview?tab=readme-ov-file#developer-brief) -

- **Product Images (Hover goes to second image)** - Already implemented, simply enable 'Show second image on hover' under the section's 'Product card' settings.
- **Product Title**—No change. The font-weight in the example looks less than that in the current theme, but I didn't want to change it and potentially introduce inconsistencies in styles between sections/card types.
- **Product Price** - Now sits on the same row as the rating.
- **Product Colours as Swatches** - Uses information from custom product metaobjects defined in the development store to render colour swatches for other products in the same group. Currently swatches link to the PDP.
- **Star Reviews** - Uses information from the custom product metafield defined in the development store to render the star rating. To see star reviews simply enable 'Show product rating' under the section's 'Product card' settings.
-  **Custom Pill Messaging** - Extends the existing product badge implementation ('Sale' & 'Sold Out') to support custom badges added as product tags. To define a custom badge simply add a tag to a product with the 'badge_' prefix (e.g. prefix_Squat_Proof). The custom badge colour can be configured using the new 'Custom badge color scheme' theme setting which can be found under 'Badges'.

**Assumptions**

I used the custom product metafield 'custom.product_rating' defined in the development store for the star reviews. The theme already included support for the standard Shopify review metafields 'reviews.rating' and 'reviews.rating_count' which I've removed. Normally I'd recommend using the standard metafields for reviews to ensure compatibility with 3rd party apps however, I assumed you wanted to specifically see I could work with your custom fields.

**Notes**

The colour swatches aren't perfectly centered. This is almost certainly due to an obvious CSS mistake which I've simply missed. For now I've decided to move on to other tasks.